### PR TITLE
use published elm-physics

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,8 +1,7 @@
 {
     "type": "application",
     "source-directories": [
-        "src",
-        "../elm-physics/src"
+        "src"
     ],
     "elm-version": "0.19.1",
     "dependencies": {
@@ -21,7 +20,8 @@
             "ianmackenzie/elm-geometry": "3.9.0",
             "ianmackenzie/elm-geometry-linear-algebra-interop": "2.0.2",
             "ianmackenzie/elm-triangular-mesh": "1.1.0",
-            "ianmackenzie/elm-units": "2.7.0"
+            "ianmackenzie/elm-units": "2.7.0",
+            "w0rm/elm-physics": "5.1.2"
         },
         "indirect": {
             "elm/random": "1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,9 @@
+# elm-rocket-league
+
+### development
+
+```
+$ npm install
+$ npm start
+$ open http://localhost:8000/src/Main.elm
+```


### PR DESCRIPTION
makes #3 a lot easier, cc @benkoshy

before, `addWheelsToWorld` ultimately fed the wheels into the view, but first, it added them to the `world`. this was overkill because they don't interact physically with anything. the physics engine is simulating a suspension system, and the wheels are just drawn on after. 

by skipping the world and handling the wheels more directly in the view, it eliminated the need for the unpublished `Body.placeIn`, so now this project just needs the published `w0rm/elm-physics`.

i updated the readme with the new, simple development instructions